### PR TITLE
remove duplicate data store

### DIFF
--- a/RecyclingAlert/DWURecyclingAlert/DWURecyclingAlert.m
+++ b/RecyclingAlert/DWURecyclingAlert/DWURecyclingAlert.m
@@ -97,11 +97,7 @@ static void removeRedBorderEffect(CALayer *layer) {
 }
 
 static void dwu_recursionHelper2(CALayer *layer) {
-    static NSMutableSet *cgImageRefSet;
     static NSMutableDictionary *cgImageRefDict;
-    if (!cgImageRefSet) {
-        cgImageRefSet = [NSMutableSet set];
-    }
     if (!cgImageRefDict) {
         cgImageRefDict = [NSMutableDictionary dictionary];
     }
@@ -112,9 +108,8 @@ static void dwu_recursionHelper2(CALayer *layer) {
     if ( layer.delegate && [layer.delegate respondsToSelector:imageSelector]) {
         UIImage *image = ((UIImage * ( *)(id, SEL))objc_msgSend)(layer.delegate, imageSelector);
         if (image) {
-            NSString *addressString = [NSString stringWithFormat:@"%@", image.CGImage];
-            if (![cgImageRefSet containsObject:addressString]) {
-                [cgImageRefSet addObject:addressString];
+            NSString *addressString = [NSString stringWithFormat:@"%p", image.CGImage];
+            if (![cgImageRefDict objectForKey:addressString]) {
                 [cgImageRefDict setObject:layer.delegate forKey:addressString];
                 imageTargetFound = YES;
             } else {


### PR DESCRIPTION
Hello @diwu,

在 trace 紅框出現的邏輯時, 發現在 `dwu_recursionHelper2` 這個 function 裡面, 有部分可以小幅修改一下,

第一個是, 我們應該可以只用一個 container 就好. 所以我把 `cgImageRefSet` 整個拆掉了.
第二個是, 純取 address 的話, 可以用 `%p` 取代 `%@`.

另外一個部分, 當 `layer.delegate` 被放到 `cgImageRefDict` 時, 會導致該目標無法被釋放, 但是要改起來的話, 會動到比較多地方, 我暫時就先不動他.
