### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![][demo]
 
-#DWURecyclingAlert
+# DWURecyclingAlert
 > Your code usually has less than ten milliseconds to run before it causes a frame drop.<sup>[1](#myfootnote1)</sup>
 >
 
@@ -8,7 +8,7 @@
 [![](https://img.shields.io/badge/license-MIT-blue.svg)][license]
 [![](https://img.shields.io/badge/swift-compatible-orange.svg)][project]
 
-#Visualize Bad Drawings On The Fly
+# Visualize Bad Drawings On The Fly
 
 Injects 4 classes:
  
@@ -31,7 +31,7 @@ Visualizes bad drawing code in 2 ways:
 * Displays non-recycled UIView, CALayer and UIImage objects with bold red bolders.
 * Displays the time it takes to complete each time sensitive API calls, in milliseconds.
 
-#Usage
+# Usage
 Step 1: Drop [DWURecyclingAlert.m][code] into your project, Swift or ObjC.
 
 Step 2: There's no step 2. 
@@ -44,21 +44,21 @@ Then manually start injection by running the following function anywhere in your
 
 `void Inject_DWURecyclingAlert();`
 
-#UI Configuration
+# UI Configuration
 It's likely that your project happens to use lots of `[UIColor redColor]` here and there. Or, maybe you want to localize the millisecond warning string with your team's first language. Take a look at the [UI Configuration][code_line_39] section and customize them the way you like.
-#How It Works
+# How It Works
 Method swizzling and associated objects. You could always read the [source][code].
 
-#Disabled in Release By Default
+# Disabled in Release By Default
 [DWURecyclingAlert.m][code] requires the DEBUG macro to compile and run. As a result, it's disabled in Release by default. If you also want to disable it in debug builds, comment out the [DWURecyclingAlertEnabled][code_line_23] macro at the top of the file.
-#Misc
+# Misc
 * Whether your cell / header / footer are created by code or by nib/storyboard, [DWURecyclingAlert.m][code] has a way to scan it.
 * It's perfectly normal for a cell to have multiple subviews that override `drawRect:`, if that's the case, [DWURecyclingAlert.m][code] will calculate the sum for all the time it takes to go through each `drawRect:` call.
 * [DWURecyclingAlert.m][code] requires iOS 6 or higher to compile.
 
-#Example Project
+# Example Project
 Inside this repo you can find the RecyclingAlert example project. 
-#License
+# License
 DWURecyclingAlert is released under the MIT license. See [LICENSE][license] for details.
 
 [code]: ./RecyclingAlert/DWURecyclingAlert/DWURecyclingAlert.m


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
